### PR TITLE
Fixes TypeError Python3

### DIFF
--- a/html2jira.py
+++ b/html2jira.py
@@ -438,7 +438,7 @@ class HTML2Jira(HTMLParser.HTMLParser):
             self.p()
             if start:
                 self.inheader = True
-                self.o("h" + hn(tag) + '. ')
+                self.o("h" + str(hn(tag)) + '. ')
             else:
                 self.inheader = False
                 return  # prevent redundant emphasis marks on headers

--- a/test/test-broken.py
+++ b/test/test-broken.py
@@ -1,0 +1,22 @@
+import sys
+import logging
+import html2jira
+
+if sys.version_info[:2] < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
+                    level=logging.DEBUG)
+
+
+class TestHtmlToJira(unittest.TestCase):
+
+        def test_broken(self):
+            parser = html2jira.HTML2Jira(bodywidth=0)
+            self.assertEqual(parser.handle("<h1>BlaBla</h1>"), "h1. BlaBla\n")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I don't know if this project is still being actively maintained.

However it is unusable in its current form (at least on python3.4/3.5) for me. I have added a minimal test case that fails with:
```python
Error
Traceback (most recent call last):
  File "/usr/lib/python3.5/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.5/unittest/case.py", line 600, in run
    testMethod()
  File "/home/ddraper/PycharmProjects/html2jira/test/test-broken.py", line 19, in test_broken
    self.assertEqual(parser.handle("<h1>BlaBla</h1>"), ".h1 BlaBla")
  File "/usr/local/lib/python3.5/dist-packages/html2jira-2014.4.5-py3.5.egg/html2jira.py", line 274, in handle
    self.feed(data)
  File "/usr/local/lib/python3.5/dist-packages/html2jira-2014.4.5-py3.5.egg/html2jira.py", line 271, in feed
    HTMLParser.HTMLParser.feed(self, data)
  File "/usr/lib/python3.5/html/parser.py", line 111, in feed
    self.goahead(0)
  File "/usr/lib/python3.5/html/parser.py", line 171, in goahead
    k = self.parse_starttag(i)
  File "/usr/lib/python3.5/html/parser.py", line 345, in parse_starttag
    self.handle_starttag(tag, attrs)
  File "/usr/local/lib/python3.5/dist-packages/html2jira-2014.4.5-py3.5.egg/html2jira.py", line 315, in handle_starttag
    self.handle_tag(tag, attrs, 1)
  File "/usr/local/lib/python3.5/dist-packages/html2jira-2014.4.5-py3.5.egg/html2jira.py", line 441, in handle_tag
    self.o("h" + hn(tag) + '. ')
TypeError: Can't convert 'int' object to str implicitly
```

The small str conversion I added fixes this case,